### PR TITLE
Expose sendGroupChatMessageWithoutJoin:completion: of QBChatDialog th…

### DIFF
--- a/QMChatService/QMChatService/QMChatService.h
+++ b/QMChatService/QMChatService/QMChatService.h
@@ -406,6 +406,28 @@ typedef NS_ENUM(NSUInteger, QMChatConnectionState) {
  *  @param message       QBChatMessage instance
  *  @param type          QMMessageType type
  *  @param dialog        QBChatDialog instance
+ *  @param withoutJoin   if YES - do not auto join the dialog if it is of type QBChatDialogTypeGroup or QBChatDialogTypePublicGroup
+ *  @param saveToHistory if YES - saves message to chat history
+ *  @param saveToStorage if YES - saves to local storage
+ *  @param completion    completion block with failure error
+ *
+ *  @discussion The purpose of this method is to have a proper way of sending messages
+ *  with a different message type, which does not have their own methods (e.g. contact request).
+ */
+- (void)sendMessage:(QBChatMessage *)message
+			   type:(QMMessageType)type
+		   toDialog:(QBChatDialog *)dialog
+		withoutJoin:(BOOL)withoutJoin
+	  saveToHistory:(BOOL)saveToHistory
+	  saveToStorage:(BOOL)saveToStorage
+		 completion:(QBChatCompletionBlock)completion;
+
+/**
+ *  Send message with a specific message type to dialog with identifier.
+ *
+ *  @param message       QBChatMessage instance
+ *  @param type          QMMessageType type
+ *  @param dialog        QBChatDialog instance
  *  @param saveToHistory if YES - saves message to chat history
  *  @param saveToStorage if YES - saves to local storage
  *  @param completion    completion block with failure error
@@ -414,11 +436,11 @@ typedef NS_ENUM(NSUInteger, QMChatConnectionState) {
  *  with a different message type, which does not have their own methods (e.g. contact request).
  */
 - (void)sendMessage:(QB_NONNULL QBChatMessage *)message
-               type:(QMMessageType)type
-           toDialog:(QB_NONNULL QBChatDialog *)dialog
-      saveToHistory:(BOOL)saveToHistory
-      saveToStorage:(BOOL)saveToStorage
-         completion:(QB_NULLABLE QBChatCompletionBlock)completion;
+			   type:(QMMessageType)type
+		   toDialog:(QB_NONNULL QBChatDialog *)dialog
+	  saveToHistory:(BOOL)saveToHistory
+	  saveToStorage:(BOOL)saveToStorage
+		 completion:(QB_NULLABLE QBChatCompletionBlock)completion;
 
 /**
  *  Send message to dialog with identifier.

--- a/QMChatService/QMChatService/QMChatService.m
+++ b/QMChatService/QMChatService/QMChatService.m
@@ -1173,65 +1173,88 @@ static NSString* const kQMChatServiceDomain = @"com.q-municate.chatservice";
 #pragma mark - Send messages
 
 - (void)sendMessage:(QBChatMessage *)message
+			   type:(QMMessageType)type
+		   toDialog:(QBChatDialog *)dialog
+		withoutJoin:(BOOL)withoutJoin
+	  saveToHistory:(BOOL)saveToHistory
+	  saveToStorage:(BOOL)saveToStorage
+		 completion:(QBChatCompletionBlock)completion
+{
+	message.dateSent = [NSDate date];
+	
+	//Save to history
+	if (saveToHistory) {
+		message.saveToHistory = kChatServiceSaveToHistoryTrue;
+	}
+	//Set message type
+	if (type != QMMessageTypeText) {
+		message.messageType = type;
+	}
+	
+	QBUUser *currentUser = self.serviceManager.currentUser;
+	
+	if (dialog.type == QBChatDialogTypePrivate) {
+		message.recipientID = dialog.recipientID;
+		message.markable = YES;
+	}
+	
+	message.senderID = currentUser.ID;
+	message.dialogID = dialog.ID;
+	
+	__weak __typeof(self)weakSelf = self;
+	void(^sendMessageCompletionBlock)(NSError *) = ^(NSError *error) {
+		__typeof(weakSelf)strongSelf = weakSelf;
+		
+		if (error == nil && saveToStorage) {
+			
+			// there is a case when message that was returned from server (Group dialogs)
+			// will be handled faster then this completion block been fired
+			// therefore there is no need to add local message to memory storage, while server
+			// up-to-date one is already there
+			BOOL messageExists = [strongSelf.messagesMemoryStorage isMessageExistent:message forDialogID:message.dialogID];
+			
+			if (!messageExists) {
+				
+				[strongSelf.messagesMemoryStorage addMessage:message forDialogID:dialog.ID];
+				
+				if ([strongSelf.multicastDelegate respondsToSelector:@selector(chatService:didAddMessageToMemoryStorage:forDialogID:)]) {
+					[strongSelf.multicastDelegate chatService:strongSelf didAddMessageToMemoryStorage:message forDialogID:dialog.ID];
+				}
+			}
+			
+			[strongSelf updateLastMessageParamsForChatDialog:dialog withMessage:message];
+			dialog.updatedAt = message.dateSent;
+			
+			if ([strongSelf.multicastDelegate respondsToSelector:@selector(chatService:didUpdateChatDialogInMemoryStorage:)]) {
+				[strongSelf.multicastDelegate chatService:strongSelf didUpdateChatDialogInMemoryStorage:dialog];
+			}
+		}
+		
+		if (completion) completion(error);
+	};
+	
+	if (withoutJoin && (dialog.type == QBChatDialogTypeGroup || dialog.type == QBChatDialogTypePublicGroup)) {
+		[dialog sendGroupChatMessageWithoutJoin:message completion:sendMessageCompletionBlock];
+	}
+	else {
+		[dialog sendMessage:message completionBlock:sendMessageCompletionBlock];
+	}
+}
+
+- (void)sendMessage:(QBChatMessage *)message
                type:(QMMessageType)type
            toDialog:(QBChatDialog *)dialog
       saveToHistory:(BOOL)saveToHistory
       saveToStorage:(BOOL)saveToStorage
          completion:(QBChatCompletionBlock)completion
 {
-    message.dateSent = [NSDate date];
-    
-    //Save to history
-    if (saveToHistory) {
-        message.saveToHistory = kChatServiceSaveToHistoryTrue;
-    }
-    //Set message type
-    if (type != QMMessageTypeText) {
-        message.messageType = type;
-    }
-    
-    QBUUser *currentUser = self.serviceManager.currentUser;
-    
-    if (dialog.type == QBChatDialogTypePrivate) {
-        message.recipientID = dialog.recipientID;
-        message.markable = YES;
-    }
-    
-    message.senderID = currentUser.ID;
-    message.dialogID = dialog.ID;
-    
-    __weak __typeof(self)weakSelf = self;
-    [dialog sendMessage:message completionBlock:^(NSError *error) {
-        
-        __typeof(weakSelf)strongSelf = weakSelf;
-    
-        if (error == nil && saveToStorage) {
-            
-            // there is a case when message that was returned from server (Group dialogs)
-            // will be handled faster then this completion block been fired
-            // therefore there is no need to add local message to memory storage, while server
-            // up-to-date one is already there
-            BOOL messageExists = [strongSelf.messagesMemoryStorage isMessageExistent:message forDialogID:message.dialogID];
-            
-            if (!messageExists) {
-                
-                [strongSelf.messagesMemoryStorage addMessage:message forDialogID:dialog.ID];
-                
-                if ([strongSelf.multicastDelegate respondsToSelector:@selector(chatService:didAddMessageToMemoryStorage:forDialogID:)]) {
-                    [strongSelf.multicastDelegate chatService:strongSelf didAddMessageToMemoryStorage:message forDialogID:dialog.ID];
-                }
-            }
-            
-            [strongSelf updateLastMessageParamsForChatDialog:dialog withMessage:message];
-            dialog.updatedAt = message.dateSent;
-            
-            if ([strongSelf.multicastDelegate respondsToSelector:@selector(chatService:didUpdateChatDialogInMemoryStorage:)]) {
-                [strongSelf.multicastDelegate chatService:strongSelf didUpdateChatDialogInMemoryStorage:dialog];
-            }
-        }
-        
-        if (completion) completion(error);
-    }];
+	[self sendMessage:message
+				 type:type
+			 toDialog:dialog
+		  withoutJoin:NO
+		saveToHistory:saveToHistory
+		saveToStorage:saveToStorage
+		   completion:completion];
 }
 
 - (void)sendMessage:(QBChatMessage *)message


### PR DESCRIPTION
…rough QMChatService via an additional version of sendMessage:

_NOTE:_
Basically all code from `sendMessage:type:toDialog:saveToHistory:saveToStorage:completion:` was moved to `sendMessage:type:toDialog:withoutJoin:saveToHistory:saveToStorage:completion:`

The only difference is that we now use `sendGroupChatMessageWithoutJoin:completion:` instead of `sendMessage:completionBlock:` whenever `withoutJoin` is set (see line 1236 t0 1240).

Please review in regard to this, as everything else is an exact copy of QuickBlox code and might hinder getting a PR into the root repo through. Thank you!
