### PR TITLE
bugfix/services_messages_cache_update

### DIFF
--- a/QMChatService/QMChatService/QMChatService.m
+++ b/QMChatService/QMChatService/QMChatService.m
@@ -1393,13 +1393,21 @@ static NSString* const kQMChatServiceDomain = @"com.q-municate.chatservice";
                                didUpdateChatDialogInMemoryStorage:chatDialogToUpdate];
                     }
                 }
-                
+				
                 // updating message in memory storage
                 [strongSelf.messagesMemoryStorage updateMessage:message];
-                
+				
+				// update message in cache
+				if ([strongSelf.multicastDelegate respondsToSelector:@selector(chatService:didUpdateMessage:forDialogID:)]) {
+					
+					[strongSelf.multicastDelegate chatService:strongSelf
+											 didUpdateMessage:message
+												  forDialogID:chatDialogToUpdate.ID];
+				}
+				
                 [updatedMessages addObject:message];
             }
-            
+			
             [strongSelf.messagesToRead removeObject:message.ID];
             
             dispatch_group_leave(readGroup);


### PR DESCRIPTION
When sending read status, do not only update the message in the memory store but also cache.
